### PR TITLE
fix: correct usage of node.hasChildNodes

### DIFF
--- a/fixtures/junit_report.xml
+++ b/fixtures/junit_report.xml
@@ -1,0 +1,7 @@
+<testsuites name="Mocha Tests">
+  <testsuite name="adb with an emulator running" tests="4" errors="0" failures="1" skipped="0" timestamp="2019-04-15T09:11:55" time="11.373">
+    <testcase classname="adb with an emulator running" name="#pull()" time="0">
+      <failure message="ENOENT: no such file or directory, unlink &apos;/Users/eharris/Documents/git/node-titanium-sdk/tests/build.prop&apos;"></failure>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -22,6 +22,16 @@ at Assertion.prop.(anonymous function) (/should.js:1411:20)
 		at Window.&lt;anonymous&gt; (/ti.ui.window.test.js:675:35)
 		at Window.value (ti:/events.js:50:21)
 		at Window.value (ti:/events.js:102:19)</pre></td></tr>
+<tr><td>adb with an emulator running</td><td>#pull()</td><td>0</td><td><pre>ENOENT: no such file or directory, unlink '/Users/eharris/Documents/git/node-titanium-sdk/tests/build.prop'</pre></td></tr>
+</table>
+"
+`;
+
+exports[`junit() Handles failures 1`] = `
+"### Tests:
+
+<table><tr><th>Classname</th><th>Name</th><th>Time</th><th>Error</th></tr>
+<tr><td>adb with an emulator running</td><td>#pull()</td><td>0</td><td><pre>ENOENT: no such file or directory, unlink '/Users/eharris/Documents/git/node-titanium-sdk/tests/build.prop'</pre></td></tr>
 </table>
 "
 `;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -63,7 +63,7 @@ describe("junit()", () => {
 
     expect(global.message).toHaveBeenCalledTimes(1)
     expect(global.message).toHaveBeenCalledWith(
-      ":x: 1 tests have failed\nThere are 1 tests failing and 3 skipped out of 22 total tests."
+      ":x: 2 tests have failed\nThere are 2 tests failing and 3 skipped out of 26 total tests."
     )
     expect(global.fail).toHaveBeenCalledTimes(1)
     expect(global.fail).toHaveBeenCalledWith("Tests have failed, see below for more information.")
@@ -79,6 +79,21 @@ describe("junit()", () => {
     expect(global.message).toHaveBeenCalledTimes(1)
     expect(global.message).toHaveBeenCalledWith(
       ":x: 2 tests have failed\nThere are 2 tests failing and 0 skipped out of 2 total tests."
+    )
+    expect(global.fail).toHaveBeenCalledTimes(1)
+    expect(global.fail).toHaveBeenCalledWith("Tests have failed, see below for more information.")
+    expect(global.markdown).toHaveBeenCalledTimes(1)
+    expect(global.markdown.mock.calls[0][0]).toMatchSnapshot()
+  })
+
+  it("Handles failures from mocha-jenkins-reporter", async () => {
+    await junit({
+      pathToReport: "./fixtures/junit_report.xml",
+    })
+
+    expect(global.message).toHaveBeenCalledTimes(1)
+    expect(global.message).toHaveBeenCalledWith(
+      ":x: 1 tests have failed\nThere are 1 tests failing and 0 skipped out of 4 total tests."
     )
     expect(global.fail).toHaveBeenCalledTimes(1)
     expect(global.fail).toHaveBeenCalledWith("Tests have failed, see below for more information.")

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ function gatherErrorDetail(failure: Element): string {
   if (failure.hasAttribute("stack")) {
     detail += "\n" + failure.getAttribute("stack")
   }
-  if (failure.hasChildNodes) {
+  if (failure.hasChildNodes()) {
     // CDATA stack trace
     detail +=
       "\n" +


### PR DESCRIPTION
Add test case from jenkins failures, update existing snapshots