### PR TITLE
feat: allow setting a custom name for test run

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -36,6 +36,19 @@ exports[`junit() Handles failures from mocha-jenkins-reporter 1`] = `
 "
 `;
 
+exports[`junit() allows setting a custom header 1`] = `
+"### My awesome tests:
+
+<table><tr><th>Classname</th><th>Name</th><th>Time</th><th>Error</th></tr>
+<tr><td>android.Titanium.UI.Window</td><td>.safeAreaPadding with extendSafeArea true</td><td>0.052</td><td><pre>AssertionError: expected 0 to be above 0
+at Assertion.prop.(anonymous function) (/should.js:1411:20)
+		at Window.&lt;anonymous&gt; (/ti.ui.window.test.js:675:35)
+		at Window.value (ti:/events.js:50:21)
+		at Window.value (ti:/events.js:102:19)</pre></td></tr>
+</table>
+"
+`;
+
 exports[`junit() handles karma junit report 1`] = `
 "### Tests:
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -115,4 +115,19 @@ Nice one! All 178 tests are passing.
     expect(global.fail).toHaveBeenCalledTimes(0)
     expect(global.markdown).toHaveBeenCalledTimes(0)
   })
+
+  it("allows setting a custom header", async () => {
+    await junit({
+      pathToReport: "./fixtures/junit_failures.xml",
+      name: "My awesome tests",
+    })
+
+    expect(global.message).toHaveBeenCalledWith(
+      ":x: 1 tests have failed\nThere are 1 tests failing and 3 skipped out of 19 total tests."
+    )
+    expect(global.fail).toHaveBeenCalledTimes(1)
+    expect(global.fail).toHaveBeenCalledWith("My awesome tests have failed, see below for more information.")
+    expect(global.markdown).toHaveBeenCalledTimes(1)
+    expect(global.markdown.mock.calls[0][0]).toMatchSnapshot()
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,10 @@ interface JUnitReportOptions {
    * Whether the test summary message will be reported using danger's `message()`. Defaults to true.
    */
   showMessageTestSummary?: boolean
+  /**
+   * Message to show at the top of the test results table. Defaults to "Tests"
+   */
+  name?: string
 }
 
 /**
@@ -50,6 +54,8 @@ export default async function junit(options: JUnitReportOptions) {
     options.pathToReport !== undefined ? options.pathToReport! : "./build/reports/**/TESTS*.xml"
   const shouldShowMessageTestSummary: boolean =
     options.showMessageTestSummary !== undefined ? options.showMessageTestSummary! : true
+
+  const name = options.name ? options.name : "Tests"
 
   // Use glob to find xml reports!
   const matches: string[] = await promisify(glob)(currentPath)
@@ -70,7 +76,7 @@ export default async function junit(options: JUnitReportOptions) {
   // Give details on failed tests
   const failuresAndErrors: Element[] = gatherFailedTestcases(suites)
   if (failuresAndErrors.length !== 0) {
-    reportFailures(failuresAndErrors)
+    reportFailures(failuresAndErrors, name)
   }
 }
 
@@ -98,9 +104,9 @@ function gatherErrorDetail(failure: Element): string {
   return detail
 }
 
-function reportFailures(failuresAndErrors: Element[]): void {
-  fail("Tests have failed, see below for more information.")
-  let testResultsTable: string = "### Tests:\n\n<table>"
+function reportFailures(failuresAndErrors: Element[], name: string): void {
+  fail(`${name} have failed, see below for more information.`)
+  let testResultsTable: string = `### ${name}:\n\n<table>`
   const keys: string[] = Array.from(failuresAndErrors[0].attributes).map((attr: Attribute) => attr.nodeName)
   const attributes: string[] = keys.map(key => {
     return key.substr(0, 1).toUpperCase() + key.substr(1).toLowerCase()


### PR DESCRIPTION
Allows setting a custom name for the table header and failure report